### PR TITLE
Fix indentation error in ethtool.py

### DIFF
--- a/addons/ethtool.py
+++ b/addons/ethtool.py
@@ -252,7 +252,7 @@ class ethtool(moduleBase,utilsBase):
             for attr in ethtool_output.splitlines():
                 if attr.startswith('FEC encodings'):
                     fec_attrs = attr.split()
-                return(fec_attrs[fec_attrs.index(':')+1])
+                    return(fec_attrs[fec_attrs.index(':')+1])
         except Exception as e:
             self.logger.debug('ethtool: problems in ethtool set-fec output'
                                ' %s: %s' %(ethtool_output.splitlines(), str(e)))


### PR DESCRIPTION
This typo breaks `get_fec_encoding` and seems to force interfaces with fec settings to be reloaded on `ifreload -a`.

```
# ifreload -a -d
...
info: executing /sbin/ethtool --show-fec swp25
debug: ethtool: problems in ethtool set-fec output ['FEC parameters for swp25:', 'FEC encodings   : None']: local variable 'fec_attrs' referenced before assignment
...
```

Thanks,
Anton

